### PR TITLE
fix: Suggestions show up when editing the selected filters

### DIFF
--- a/src/OTokenizer.js
+++ b/src/OTokenizer.js
@@ -47,7 +47,7 @@ export default class OTokenizer extends Tokenizer {
 	    const node = ReactDOM.findDOMNode(this)
 	    if (
 	      (node && node.contains(e.target)) ||
-				((e.target && e.target.closest('.typeahead-option')) || e.target.className === 'typeahead-token-close' || e.target.className === 'typeahead-token')
+				((e.target && e.target.closest('.typeahead-option')) || e.target.className === 'typeahead-token-close' || e.target.closest('.typeahead-token'))
 	    ) {
 	      return
 	    }


### PR DESCRIPTION
While editing the selected tokens suggestions show up 
issue- suggestions were not showing up because of the focus condition evaluation
root cause: Selected token internal structure changed from string to html spans which had resulted in disabling the suggestions
 
 